### PR TITLE
Исправление установки цвета.

### DIFF
--- a/modules/xiaomihome/xiaomihome.class.php
+++ b/modules/xiaomihome/xiaomihome.class.php
@@ -722,7 +722,7 @@ class xiaomihome extends module
                     $sendvalue = hexdec($value);
                     $data['cmd'] = 'write';
                     $data['model'] = 'gateway';
-                    $cmd_data['rgb'] = $sendvalue;
+                    $cmd_data['brightness'] = $sendvalue;
                 }
 
                 if ($command['TITLE'] == 'rgb') {


### PR DESCRIPTION
При установке цвета, а затем яркости, установка яркости сбивала цвет и устанавливала его в #000000.